### PR TITLE
Improve encryption with AES-GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple AES File Encrypt/Decrypt Scripts
 
-**Verschlüssle und entschlüssele alle Dateien in einem Ordner (inkl. Unterordner) mit AES-256.**
+**Verschlüssle und entschlüssele alle Dateien in einem Ordner (inkl. Unterordner) mit AES-256-GCM.**
 
 ## Voraussetzungen
 
@@ -20,17 +20,17 @@
   python3 encrypt_all.py
   ```
 - Der erzeugte BASE64-Schlüssel wird angezeigt – **unbedingt sichern!**
-- Alle Dateien werden als `.enc` verschlüsselt, Originaldateien werden gelöscht.
+- Alle Dateien werden als `.mock` verschlüsselt, Originaldateien werden gelöscht.
 
 ### 2. Entschlüsseln
 
-- Passe `START_PATH` in `decrypt_all.py` auf das Verzeichnis mit den `.enc`-Dateien an.
+- Passe `START_PATH` in `decrypt_all.py` auf das Verzeichnis mit den `.mock`-Dateien an.
 - Trage den beim Verschlüsseln erhaltenen Schlüssel (BASE64) bei `KEY_B64` ein.
 - Starte das Skript:
   ```
   python3 decrypt_all.py
   ```
-- Die Dateien werden wiederhergestellt, `.enc`-Dateien werden gelöscht.
+- Die Dateien werden wiederhergestellt, `.mock`-Dateien werden gelöscht.
 
 ## Hinweise
 

--- a/encrypt_all.py
+++ b/encrypt_all.py
@@ -6,18 +6,18 @@ from Crypto.Random import get_random_bytes
 # Zielordner anpassen!
 START_PATH = "folder"
 KEY_FILENAME = "MOCKBIT_KEY.txt"
+NONCE_SIZE = 12  # Bytes for AES-GCM nonce
 
-def pad(data):
-    pad_length = AES.block_size - (len(data) % AES.block_size)
-    return data + bytes([pad_length]) * pad_length
+
 
 def encrypt_file(file_path, key):
     with open(file_path, "rb") as f:
         data = f.read()
-    cipher = AES.new(key, AES.MODE_CBC)
-    ct_bytes = cipher.encrypt(pad(data))
+    nonce = get_random_bytes(NONCE_SIZE)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ct_bytes, tag = cipher.encrypt_and_digest(data)
     with open(file_path + ".mock", "wb") as f:
-        f.write(cipher.iv + ct_bytes)
+        f.write(nonce + tag + ct_bytes)
     os.remove(file_path)
 
 def find_and_encrypt_all_files(path, key):


### PR DESCRIPTION
## Summary
- use AES-GCM mode to detect wrong keys
- update decryption logic for AES-GCM
- document `.mock` extension and GCM mode

## Testing
- `python3 -m py_compile encrypt_all.py decrypt_all.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd82c2e048332bfc51d47912d53b9