### PR TITLE
Ensure TMPDIR and PATH for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ make          # just build
 ./compile.sh  # install deps & build
 ```
 
+`compile.sh` creates `~/tmp` and sets `TMPDIR` automatically so the build works
+on systems where `/tmp` is mounted with `noexec`. If you run the scripts
+directly, export `TMPDIR=$HOME/tmp` yourself.
+
 The binaries are placed in **bin/**.  
 Run `make clean` to remove build artefacts.
 
@@ -69,6 +73,10 @@ pip3 install -r requirements.txt
 make          # nur bauen
 ./compile.sh  # Abhängigkeiten installieren und bauen
 ```
+
+`compile.sh` legt automatisch `~/tmp` an und setzt `TMPDIR`, falls `/tmp` mit
+`noexec` eingehängt ist. Wenn du die Skripte direkt aufrufst, setze
+`TMPDIR=$HOME/tmp` selbst.
 
 Die Binaries liegen anschließend in **bin/**.  
 Mit `make clean` entfernst du die Build-Dateien.

--- a/compile.sh
+++ b/compile.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Ensure a writable temporary directory on systems where /tmp is noexec
+mkdir -p "$HOME/tmp"
+export TMPDIR="$HOME/tmp"
+
+# Ensure pip-installed executables are found
+export PATH="$HOME/.local/bin:$PATH"
+
 # Install build dependencies and invoke the Makefile
 python3 -m pip install --user -r requirements.txt
 python3 -m pip install --user pyinstaller


### PR DESCRIPTION
## Summary
- create a per-user tmp dir and set `TMPDIR` in `compile.sh`
- add `~/\.local/bin` to `PATH` during build
- document TMPDIR handling in the README

## Testing
- `python3 -m py_compile encrypt_all.py decrypt_all.py`
- `bash compile.sh > /tmp/compile.log` *(successfully built, log truncated)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_684c03af39a883328bdff283b2d792bf