### PR TITLE
Add CLI args for encrypt/decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Run `make clean` to remove build artefacts.
 
 | Step | Action | Command / Notes |
 |------|--------|-----------------|
-| 1 | **Encrypt** | Adjust `START_PATH` in `encrypt_all.py`, then:<br>`python3 encrypt_all.py`<br>Enter passphrase → key derived via Argon2id<br>Salt & Argon2 params saved to **MOCKBIT_KEY.txt**<br>Original files deleted, encrypted copies end with **.mock**<br>The **base64 key** is printed – **save it!** |
-| 2 | **Decrypt** | Adjust `START_PATH` in `decrypt_all.py`, ensure **MOCKBIT_KEY.txt** is present, then:<br>`python3 decrypt_all.py`<br>Enter the same passphrase → files are restored, `.mock` files removed |
+| 1 | **Encrypt** | `python3 encrypt_all.py --path folder` (add `--time`, `--memory`, `--parallelism` if needed)<br>Enter passphrase → key derived via Argon2id<br>Salt & Argon2 params saved to **MOCKBIT_KEY.txt**<br>Original files deleted, encrypted copies end with **.mock** |
+| 2 | **Decrypt** | `python3 decrypt_all.py --path folder` (same optional parameters)<br>Enter the same passphrase → files are restored, `.mock` files removed |
 
 ### Notes
 * **Always test in a safe environment first.**
@@ -85,8 +85,8 @@ Mit `make clean` entfernst du die Build-Dateien.
 
 | Schritt | Aktion | Befehl / Hinweise |
 |---------|--------|-------------------|
-| 1 | **Verschlüsseln** | `START_PATH` in `encrypt_all.py` anpassen, dann:<br>`python3 encrypt_all.py`<br>Passphrase eingeben → Schlüssel wird via Argon2id abgeleitet<br>Salz & Argon2‑Parameter in **MOCKBIT_KEY.txt**<br>Originale werden sicher gelöscht, verschlüsselte Dateien enden auf **.mock**<br>Der **Base64‑Schlüssel** wird angezeigt – **unbedingt aufbewahren!** |
-| 2 | **Entschlüsseln** | `START_PATH` in `decrypt_all.py` anpassen, sicherstellen, dass **MOCKBIT_KEY.txt** vorhanden ist, dann:<br>`python3 decrypt_all.py`<br>Dieselbe Passphrase eingeben → Dateien werden wiederhergestellt, `.mock`‑Dateien entfernt |
+| 1 | **Verschlüsseln** | `python3 encrypt_all.py --path ordner` (optional `--time`, `--memory`, `--parallelism`)<br>Passphrase eingeben → Schlüssel wird via Argon2id abgeleitet<br>Salz & Argon2‑Parameter in **MOCKBIT_KEY.txt**<br>Originale werden sicher gelöscht, verschlüsselte Dateien enden auf **.mock** |
+| 2 | **Entschlüsseln** | `python3 decrypt_all.py --path ordner` (gleiche optionale Parameter)<br>Dieselbe Passphrase eingeben → Dateien werden wiederhergestellt, `.mock`‑Dateien entfernt |
 
 ### Hinweise
 * **Unbedingt zuerst in einer Testumgebung ausprobieren.**

--- a/encrypt_all.py
+++ b/encrypt_all.py
@@ -2,11 +2,12 @@ import os
 import json
 import base64
 import getpass
+import argparse
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 from argon2.low_level import hash_secret_raw, Type
 
-# Zielordner anpassen!
+# Default options
 START_PATH = "folder"
 KEY_FILENAME = "MOCKBIT_KEY.txt"
 NONCE_SIZE = 12  # Bytes for AES-GCM nonce
@@ -14,6 +15,36 @@ SALT_SIZE = 16  # Bytes for Argon2 salt
 ARGON2_TIME = 2         # Number of iterations
 ARGON2_MEMORY = 102400  # Memory cost in kibibytes
 ARGON2_PARALLELISM = 8  # Degree of parallelism
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Encrypt all files in a folder recursively"
+    )
+    parser.add_argument(
+        "--path",
+        default=START_PATH,
+        help="Target directory (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--time",
+        type=int,
+        default=ARGON2_TIME,
+        help="Argon2 time cost (iterations)",
+    )
+    parser.add_argument(
+        "--memory",
+        type=int,
+        default=ARGON2_MEMORY,
+        help="Argon2 memory cost in KiB",
+    )
+    parser.add_argument(
+        "--parallelism",
+        type=int,
+        default=ARGON2_PARALLELISM,
+        help="Argon2 degree of parallelism",
+    )
+    return parser.parse_args()
 
 def encrypt_file(file_path, key):
     with open(file_path, "rb") as f:
@@ -54,27 +85,32 @@ def find_and_encrypt_all_files(path, key):
                 print("Fehler bei", file_path, e)
 
 if __name__ == "__main__":
-    passphrase = getpass.getpass("Bitte Passphrase zum Verschlüsseln eingeben:\n")
+    args = parse_args()
+
+    passphrase = getpass.getpass(
+        "Bitte Passphrase zum Verschlüsseln eingeben:\n"
+    )
     salt = get_random_bytes(SALT_SIZE)
     key = hash_secret_raw(
         secret=passphrase.encode(),
         salt=salt,
-        time_cost=ARGON2_TIME,
-        memory_cost=ARGON2_MEMORY,
-        parallelism=ARGON2_PARALLELISM,
+        time_cost=args.time,
+        memory_cost=args.memory,
+        parallelism=args.parallelism,
         hash_len=32,
         type=Type.ID,
     )
 
-    key_path = os.path.join(START_PATH, KEY_FILENAME)
+    key_path = os.path.join(args.path, KEY_FILENAME)
     key_info = {
         "salt": base64.b64encode(salt).decode(),
-        "time": ARGON2_TIME,
-        "memory": ARGON2_MEMORY,
-        "parallelism": ARGON2_PARALLELISM,
+        "time": args.time,
+        "memory": args.memory,
+        "parallelism": args.parallelism,
     }
     with open(key_path, "w") as f:
         json.dump(key_info, f)
     print(f"Parameter wurden in {key_path} gespeichert. Passphrase merken!")
-    find_and_encrypt_all_files(START_PATH, key)
+    print(f"Starte Verschlüsselung in: {args.path}")
+    find_and_encrypt_all_files(args.path, key)
     print("Fertig.")


### PR DESCRIPTION
## Summary
- switch encrypt/decrypt helpers to argparse
- document `--path`, `--time`, `--memory`, `--parallelism` flags in README

## Testing
- `python3 encrypt_all.py --help | head -n 20`
- `python3 decrypt_all.py --help | head -n 20`
- `python3 -m py_compile encrypt_all.py decrypt_all.py`

------
https://chatgpt.com/codex/tasks/task_e_684c085af8088332a973e4e02354be62