### PR TITLE
Add ransom note option for EDR testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ _Einfache AES-Datei-Verschlüsselungs-/-Entschlüsselungsskripte_
 * Encrypt **and** decrypt every file in a folder (recursively) with **AES-256-GCM**.  
 * Password-based key derivation via **Argon2id**.  
 * Stand‑alone binaries can be built with **make / PyInstaller**.
+* Optional flags create EDR test artefacts like the EICAR file or a ransom note.
 
 ### Requirements
 * Python 3.8+  
@@ -37,7 +38,7 @@ Run `make clean` to remove build artefacts.
 
 | Step | Action | Command / Notes |
 |------|--------|-----------------|
-| 1 | **Encrypt** | `python3 encrypt_all.py --path folder` (add `--time`, `--memory`, `--parallelism` if needed)<br>Enter passphrase → key derived via Argon2id<br>Salt & Argon2 params saved to **MOCKBIT_KEY.txt**<br>Original files deleted, encrypted copies end with **.mock** |
+| 1 | **Encrypt** | `python3 encrypt_all.py --path folder` (add `--time`, `--memory`, `--parallelism`, `--ransom-sim`, `--ransom-note` if needed)<br>Enter passphrase → key derived via Argon2id<br>Salt & Argon2 params saved to **MOCKBIT_KEY.txt**<br>Original files deleted, encrypted copies end with **.mock** |
 | 2 | **Decrypt** | `python3 decrypt_all.py --path folder` (same optional parameters)<br>Enter the same passphrase → files are restored, `.mock` files removed |
 
 ### Notes
@@ -57,6 +58,7 @@ Use at your own risk. No liability for data loss or misuse.
 * **AES‑256‑GCM** zum Verschlüsseln **und** Entschlüsseln aller Dateien eines Ordners (inkl. Unterordner).  
 * Passwortbasierte Schlüsselableitung mit **Argon2id**.  
 * Erstellung eigenständiger Binaries per **make / PyInstaller**.
+* Optionale Flags erzeugen EDR-Testdateien wie EICAR oder eine Ransom-Note.
 
 ### Voraussetzungen
 * Python 3.8+  
@@ -85,7 +87,7 @@ Mit `make clean` entfernst du die Build-Dateien.
 
 | Schritt | Aktion | Befehl / Hinweise |
 |---------|--------|-------------------|
-| 1 | **Verschlüsseln** | `python3 encrypt_all.py --path ordner` (optional `--time`, `--memory`, `--parallelism`)<br>Passphrase eingeben → Schlüssel wird via Argon2id abgeleitet<br>Salz & Argon2‑Parameter in **MOCKBIT_KEY.txt**<br>Originale werden sicher gelöscht, verschlüsselte Dateien enden auf **.mock** |
+| 1 | **Verschlüsseln** | `python3 encrypt_all.py --path ordner` (optional `--time`, `--memory`, `--parallelism`, `--ransom-sim`, `--ransom-note`)<br>Passphrase eingeben → Schlüssel wird via Argon2id abgeleitet<br>Salz & Argon2‑Parameter in **MOCKBIT_KEY.txt**<br>Originale werden sicher gelöscht, verschlüsselte Dateien enden auf **.mock** |
 | 2 | **Entschlüsseln** | `python3 decrypt_all.py --path ordner` (gleiche optionale Parameter)<br>Dieselbe Passphrase eingeben → Dateien werden wiederhergestellt, `.mock`‑Dateien entfernt |
 
 ### Hinweise

--- a/encrypt_all.py
+++ b/encrypt_all.py
@@ -44,6 +44,16 @@ def parse_args():
         default=ARGON2_PARALLELISM,
         help="Argon2 degree of parallelism",
     )
+    parser.add_argument(
+        "--ransom-sim",
+        action="store_true",
+        help="Create a ransomware simulation file (EICAR test string)",
+    )
+    parser.add_argument(
+        "--ransom-note",
+        action="store_true",
+        help="Write a simple ransom note for easier EDR detection",
+    )
     return parser.parse_args()
 
 def encrypt_file(file_path, key):
@@ -84,6 +94,33 @@ def find_and_encrypt_all_files(path, key):
             except Exception as e:
                 print("Fehler bei", file_path, e)
 
+def write_ransomware_simulation_file(path):
+    """Create the standard EICAR test file as a ransomware simulation."""
+    artifact_path = os.path.join(path, "EICAR_TEST_FILE.txt")
+    eicar = (
+        "X5O!P%@AP[4\\PZX54(P^)7CC)7}$" "EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+    )
+    try:
+        with open(artifact_path, "w") as f:
+            f.write(eicar)
+        print("Ransomware-Testdatei erstellt:", artifact_path)
+    except Exception as e:
+        print("Konnte Ransomware-Testdatei nicht erstellen:", e)
+
+def write_ransom_note(path):
+    """Write a simple ransom note to help EDR solutions flag the activity."""
+    note_path = os.path.join(path, "RANSOM_NOTE.txt")
+    note = (
+        "Your files have been encrypted as part of a simulation.\n"
+        "Use decrypt_all.py with the original passphrase to restore them.\n"
+    )
+    try:
+        with open(note_path, "w") as f:
+            f.write(note)
+        print("Ransom Note erstellt:", note_path)
+    except Exception as e:
+        print("Konnte Ransom Note nicht erstellen:", e)
+
 if __name__ == "__main__":
     args = parse_args()
 
@@ -113,4 +150,8 @@ if __name__ == "__main__":
     print(f"Parameter wurden in {key_path} gespeichert. Passphrase merken!")
     print(f"Starte Verschlüsselung in: {args.path}")
     find_and_encrypt_all_files(args.path, key)
+    if args.ransom_sim:
+        write_ransomware_simulation_file(args.path)
+    if args.ransom_note:
+        write_ransom_note(args.path)
     print("Fertig.")


### PR DESCRIPTION
## Summary
- mention detection flags in README features
- allow creating a simple ransom note via `--ransom-note`
- document the new flag in usage tables

## Testing
- `python3 -m py_compile encrypt_all.py decrypt_all.py`


------
https://chatgpt.com/codex/tasks/task_e_684fee96259083328435936b1d9d9b41