### PR TITLE
Improve screenshot forwarding via MCP

### DIFF
--- a/MCPExamples/screenshot_forward_server.py
+++ b/MCPExamples/screenshot_forward_server.py
@@ -1,0 +1,22 @@
+import io
+import os
+from flask import Flask, request, jsonify
+import requests
+
+app = Flask(__name__)
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    forward_url = request.form.get('forward_url') or os.environ.get('DEFAULT_FORWARD_URL')
+    if not file:
+        return jsonify({'error': 'No file'}), 400
+    data = file.read()
+    if forward_url:
+        # Forward screenshot to the requesting LLM via MCP
+        resp = requests.post(forward_url, files={'file': ('screenshot.png', data, 'image/png')})
+        return jsonify({'forward_status': resp.status_code})
+    return jsonify({'received': len(data)})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/README.md
+++ b/README.md
@@ -98,3 +98,42 @@ Mit `make clean` entfernst du die Build-Dateien.
 
 ### Haftungsausschluss
 Benutzung auf eigene Gefahr. Keine Haftung für Datenverlust oder Missbrauch.
+
+## Unity Screenshot Example
+
+The `UnityExamples/ScreenshotUploader.cs` script demonstrates how to capture a screenshot in Unity and upload it to a server. Set `uploadUrl` to your MCP endpoint and `llmUrl` if a language model should receive the screenshot. The script can:
+
+1. **Capture & Upload Screenshot** – send the image to `uploadUrl`.
+2. **Capture & Send To LLM Directly** – post straight to `llmUrl`.
+3. **Capture & Forward via MCP** – upload to `uploadUrl` and include `llmUrl` in the form so your MCP server can forward it to the requesting LLM.
+
+If `autoSendOnStart` is enabled on the component, the screenshot will be captured
+and forwarded automatically when the scene starts, giving the LLM immediate
+visual context.
+
+The example uses `UnityWebRequest` and logs the server response. Tools typically rely on a similar HTTP request from the client and let the MCP handle forwarding to an LLM. Direct integration with GitHub Copilot isn't possible, but this pattern allows your own backend or LLM service to analyze the project.
+
+### Simple MCP Forwarding Server
+
+Use `MCPExamples/screenshot_forward_server.py` as a lightweight MCP endpoint. It
+accepts a screenshot via `POST /upload` and forwards the image to the given
+`forward_url`. If none is provided, it checks the environment variable
+`DEFAULT_FORWARD_URL` so screenshots can be automatically sent to a fixed LLM
+endpoint.
+
+```bash
+pip install -r requirements.txt
+python3 MCPExamples/screenshot_forward_server.py
+```
+
+Set `DEFAULT_FORWARD_URL` before starting the server if you want every
+uploaded screenshot to be forwarded automatically:
+
+```bash
+export DEFAULT_FORWARD_URL="https://my-llm-server.example/upload"
+python3 MCPExamples/screenshot_forward_server.py
+```
+
+Point `uploadUrl` in `ScreenshotUploader` to `http://localhost:8000/upload` and
+set `llmUrl` to the `forward_url` provided by the MCP. This mirrors how other
+tools return data to the chat that triggered them.

--- a/UnityExamples/ScreenshotUploader.cs
+++ b/UnityExamples/ScreenshotUploader.cs
@@ -1,0 +1,119 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+public class ScreenshotUploader : MonoBehaviour
+{
+    [SerializeField]
+    private string uploadUrl = "http://localhost:8000/upload"; // Replace with your MCP server URL
+
+    [SerializeField]
+    private string llmUrl = "http://localhost:8000/llm"; // Endpoint of the LLM requesting the screenshot
+
+    [SerializeField]
+    private bool autoSendOnStart = false; // If true, capture a screenshot automatically on start
+
+    private void Start()
+    {
+        if (autoSendOnStart)
+        {
+            StartCoroutine(CaptureAndUploadViaMcpCoroutine());
+        }
+    }
+
+    [ContextMenu("Capture & Upload Screenshot")]
+    public void CaptureAndUpload()
+    {
+        StartCoroutine(CaptureAndUploadCoroutine(uploadUrl));
+    }
+
+    [ContextMenu("Capture & Send To LLM Directly")]
+    public void CaptureAndUploadToLLM()
+    {
+        StartCoroutine(CaptureAndUploadCoroutine(llmUrl));
+    }
+
+    [ContextMenu("Capture & Forward via MCP")]
+    public void CaptureAndForwardViaMcp()
+    {
+        StartCoroutine(CaptureAndUploadViaMcpCoroutine());
+    }
+
+    /// <summary>
+    /// Capture a screenshot and upload it to the MCP server. The llmUrl is sent
+    /// as an additional form field so the server can forward the image to the
+    /// requesting LLM.
+    /// </summary>
+    private IEnumerator CaptureAndUploadViaMcpCoroutine()
+    {
+        yield return CaptureAndUploadCoroutine(uploadUrl, llmUrl);
+    }
+
+    /// <summary>
+    /// Capture a screenshot and upload it to the given URL (e.g. your MCP server).
+    /// </summary>
+    private IEnumerator CaptureAndUploadCoroutine(string targetUrl, string forwardUrl = null)
+    {
+        // Capture screenshot as texture
+        int width = Screen.width;
+        int height = Screen.height;
+        Texture2D screenshot = new Texture2D(width, height, TextureFormat.RGB24, false);
+
+        yield return new WaitForEndOfFrame();
+        screenshot.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+        screenshot.Apply();
+
+        byte[] bytes = screenshot.EncodeToPNG();
+        Destroy(screenshot);
+
+        // Send screenshot to server
+        WWWForm form = new WWWForm();
+        form.AddBinaryData("file", bytes, "screenshot.png", "image/png");
+
+        if (!string.IsNullOrEmpty(forwardUrl))
+        {
+            form.AddField("forward_url", forwardUrl);
+        }
+
+        UnityWebRequest www = UnityWebRequest.Post(targetUrl, form);
+        yield return www.SendWebRequest();
+
+        if (www.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError("Upload failed: " + www.error);
+        }
+        else
+        {
+            Debug.Log("Upload complete: " + www.downloadHandler.text);
+        }
+    }
+}
+
+#if UNITY_EDITOR
+[CustomEditor(typeof(ScreenshotUploader))]
+public class ScreenshotUploaderEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        ScreenshotUploader uploader = (ScreenshotUploader)target;
+        if (GUILayout.Button("Capture && Upload Screenshot"))
+        {
+            uploader.CaptureAndUpload();
+        }
+        if (GUILayout.Button("Capture && Send To LLM Directly"))
+        {
+            uploader.CaptureAndUploadToLLM();
+        }
+        if (GUILayout.Button("Capture && Forward via MCP"))
+        {
+            uploader.CaptureAndForwardViaMcp();
+        }
+    }
+}
+#endif

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pycryptodome
 argon2-cffi
+Flask
+requests


### PR DESCRIPTION
## Summary
- expand Unity screenshot uploader with an MCP-forwarding option
- document how screenshots can be forwarded to an LLM via MCP
- add simple Flask server example that forwards screenshots back to the chat
- allow automatic forwarding via `DEFAULT_FORWARD_URL` and auto-send on startup

## Testing
- `pip install -r requirements.txt`
- `pip install pyinstaller`
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6851308ac74c83329ed844b934d90256