### PR TITLE
Fix run_simulation import

### DIFF
--- a/encrypt_all.py
+++ b/encrypt_all.py
@@ -137,20 +137,12 @@ if __name__ == "__main__":
         if file_count > 10000 and not args.force:
             print(f"{file_count} files detected. Re-run with --force to continue.")
             sys.exit(1)
-            exit(1)
-        if shutil.disk_usage(sim_dir).free < 10 * 1024 * 1024:
-            print("Not enough free space for simulation.")
-            exit(1)
-        file_count = sum(len(files) for _, _, files in os.walk(sim_dir))
-        if file_count > 10000 and not args.force:
-            print(f"{file_count} files detected. Re-run with --force to continue.")
-            exit(1)
-            from mockbit.ransom_sim import run_simulation
+
+        from mockbit.ransom_sim import run_simulation
 
         print("\033[91m⚠️  Ransom-Sim mode active – EDR alarms expected.\033[0m")
         run_simulation(sim_dir)
         sys.exit(0)
-        exit(0)
 
     passphrase = getpass.getpass(
         "Bitte Passphrase zum Verschlüsseln eingeben:\n"


### PR DESCRIPTION
## Summary
- fix indentation of ransomware simulation block in encrypt_all

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685161f899bc83329e8c7561529dedcd