### PR TITLE
Add ransomware sim restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run `make clean` to remove build artefacts.
 Use at your own risk. No liability for data loss or misuse.
 
 ### 🧪 Ransomware-Simulation Mode
-Enable via `--ransom-sim` and optional `--sim-path` (defaults to `./testdata`). The tool XOR-encrypts files to `<name>.mocklock`, writes a ransom note and echoes a fake backup wipe. This helps EDR or XDR solutions detect malicious activity. The encryption key is always 0xAA so data can be restored. Run only in disposable test directories.
+Enable via `--ransom-sim` and optional `--sim-path` (defaults to `./testdata`). The tool XOR-encrypts files to `<name>.mocklock`, writes a ransom note and echoes a fake backup wipe. This helps EDR or XDR solutions detect malicious activity. The encryption key is always 0xAA so data can be restored. Run only in disposable test directories. To undo the simulation, run `python3 decrypt_all.py --ransom-sim --sim-path <dir>` on the same directory.
 
 ---
 

--- a/decrypt_all.py
+++ b/decrypt_all.py
@@ -9,9 +9,12 @@ from pathlib import Path
 import importlib.util
 from Crypto.Cipher import AES
 from argon2.low_level import hash_secret_raw, Type
+from concurrent.futures import ThreadPoolExecutor
+import tempfile
+import subprocess
 
 try:
-    from mockbit.ransom_sim import run_simulation as _ransom_sim
+    from mockbit.ransom_sim import restore_simulation as _restore_sim
 except Exception:  # pragma: no cover - optional module for binaries
     try:
         mod_path = Path(__file__).with_name("mockbit") / "ransom_sim.py"
@@ -19,11 +22,53 @@ except Exception:  # pragma: no cover - optional module for binaries
         if spec and spec.loader:
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
-            _ransom_sim = mod.run_simulation
+            _restore_sim = mod.restore_simulation
         else:
-            _ransom_sim = None
+            _restore_sim = None
     except Exception:
-        _ransom_sim = None
+        _restore_sim = None
+
+if _restore_sim is None:
+    def _restore_sim(target_dir: Path, threads: int = 8) -> None:
+        """Fallback restore if module import fails."""
+        _KEY = 0xAA
+
+        def _xor_bytes(data: bytes) -> bytes:
+            return bytes(b ^ _KEY for b in data)
+
+        def _process_file(file_path: Path) -> None:
+            if not file_path.name.endswith(".mocklock"):
+                return
+            try:
+                with open(file_path, "rb") as f:
+                    data = f.read()
+                dec = _xor_bytes(data)
+                tmp_fd, tmp_name = tempfile.mkstemp(dir=str(file_path.parent))
+                with os.fdopen(tmp_fd, "wb") as tmp:
+                    tmp.write(dec)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                out = file_path.with_suffix("")
+                os.replace(tmp_name, out)
+                os.unlink(file_path)
+            except Exception:
+                pass
+
+        with ThreadPoolExecutor(max_workers=threads) as exe:
+            for dirpath, _, files in os.walk(target_dir):
+                root = Path(dirpath)
+                for name in files:
+                    fp = root / name
+                    if not fp.is_file() or fp.is_symlink():
+                        continue
+                    if not fp.name.endswith(".mocklock"):
+                        continue
+                    exe.submit(_process_file, fp)
+                note = root / "README_MOCKBIT_RESTORE.txt"
+                try:
+                    note.unlink()
+                except Exception:
+                    pass
 
 # Default options
 START_PATH = "folder"
@@ -46,7 +91,7 @@ def parse_args():
     parser.add_argument(
         "--ransom-sim",
         action="store_true",
-        help="Run ransomware simulation instead of decryption",
+        help="Restore files created by the ransomware simulation",
     )
     parser.add_argument(
         "--sim-path",
@@ -120,22 +165,13 @@ if __name__ == "__main__":
         if file_count > 10000 and not args.force:
             print(f"{file_count} files detected. Re-run with --force to continue.")
             sys.exit(1)
-            exit(1)
-        if shutil.disk_usage(sim_dir).free < 10 * 1024 * 1024:
-            print("Not enough free space for simulation.")
-            exit(1)
-        file_count = sum(len(files) for _, _, files in os.walk(sim_dir))
-        if file_count > 10000 and not args.force:
-            print(f"{file_count} files detected. Re-run with --force to continue.")
-            exit(1)
-        if _ransom_sim is None:
+        if _restore_sim is None:
             print("Ransom simulation module unavailable.")
             sys.exit(1)
 
-        print("\033[91m⚠️  Ransom-Sim mode active – EDR alarms expected.\033[0m")
-        _ransom_sim(sim_dir)
+        print("\033[91m⚠️  Ransom-Sim restore mode active – EDR alarms expected.\033[0m")
+        _restore_sim(sim_dir)
         sys.exit(0)
-        exit(0)
 
     key_path = os.path.join(args.path, KEY_FILENAME)
     if not os.path.exists(key_path):

--- a/encrypt_all.py
+++ b/encrypt_all.py
@@ -10,6 +10,9 @@ import importlib.util
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 from argon2.low_level import hash_secret_raw, Type
+from concurrent.futures import ThreadPoolExecutor
+import tempfile
+import subprocess
 
 try:
     from mockbit.ransom_sim import run_simulation as _ransom_sim
@@ -25,6 +28,50 @@ except Exception:  # pragma: no cover - optional module for binaries
             _ransom_sim = None
     except Exception:
         _ransom_sim = None
+
+if _ransom_sim is None:
+    def _ransom_sim(target_dir: Path, threads: int = 8) -> None:
+        """Fallback ransomware simulation if module import fails."""
+        NOTE_TEXT = (
+            "Your files have been encrypted by MockBit-Test.\n"
+            "This is ONLY a test. No real ransom. Key = AA.\n"
+        )
+        _KEY = 0xAA
+
+        def _xor_bytes(data: bytes) -> bytes:
+            return bytes(b ^ _KEY for b in data)
+
+        def _process_file(file_path: Path) -> None:
+            try:
+                with open(file_path, "rb") as f:
+                    data = f.read()
+                enc = _xor_bytes(data)
+                tmp_fd, tmp_name = tempfile.mkstemp(dir=str(file_path.parent))
+                with os.fdopen(tmp_fd, "wb") as tmp:
+                    tmp.write(enc)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                out = file_path.with_suffix(file_path.suffix + ".mocklock")
+                os.replace(tmp_name, out)
+                os.unlink(file_path)
+            except Exception:
+                pass
+
+        with ThreadPoolExecutor(max_workers=threads) as exe:
+            for dirpath, _, files in os.walk(target_dir):
+                root = Path(dirpath)
+                for name in files:
+                    fp = root / name
+                    if not fp.is_file() or fp.is_symlink():
+                        continue
+                    exe.submit(_process_file, fp)
+                note = root / "README_MOCKBIT_RESTORE.txt"
+                try:
+                    with open(note, "w") as f:
+                        f.write(NOTE_TEXT)
+                except Exception:
+                    pass
+        subprocess.run(["/bin/echo", "simulate rm -rf /home/*/.snapshots"])
 
 # Default options
 START_PATH = "folder"

--- a/tests/test_ransom_sim.py
+++ b/tests/test_ransom_sim.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from mockbit.ransom_sim import run_simulation, _xor_bytes
+from mockbit.ransom_sim import run_simulation, restore_simulation, _xor_bytes
 
 
 def test_ransom_sim(tmp_path):
@@ -25,3 +25,18 @@ def test_ransom_sim(tmp_path):
         assert locked.exists()
         enc = locked.read_bytes()
         assert _xor_bytes(enc) == data
+
+def test_restore_sim(tmp_path):
+    original = {}
+    for i in range(5):
+        f = tmp_path / f"orig{i}.txt"
+        data = os.urandom(32)
+        f.write_bytes(data)
+        original[f] = data
+    run_simulation(tmp_path)
+    restore_simulation(tmp_path)
+    for f, data in original.items():
+        assert f.exists()
+        assert f.read_bytes() == data
+    assert not (tmp_path / "README_MOCKBIT_RESTORE.txt").exists()
+


### PR DESCRIPTION
## Summary
- implement `restore_simulation` helper in `mockbit.ransom_sim`
- add `--ransom-sim` restore mode to `decrypt_all.py`
- document restore usage in README
- test restoring simulated ransomware encryption

## Testing
- `pytest -q`
- `python3 encrypt_all.py --ransom-sim --sim-path tmp/testdir --force`
- `python3 decrypt_all.py --ransom-sim --sim-path tmp/testdir --force`

------
https://chatgpt.com/codex/tasks/task_e_68516d1b11b4833299a07a889f346f15