### PR TITLE
Refine Linux payload to simulate ransomware for EDR testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Einfache AES-Datei-Verschlüsselungs-/-Entschlüsselungsskripte_
 * Encrypt **and** decrypt every file in a folder (recursively) with **AES-256-GCM**.  
 * Password-based key derivation via **Argon2id**.  
 * Stand‑alone binaries can be built with **make / PyInstaller**.
-* Optional flags create EDR test artefacts like the EICAR file or a ransom note.
+* Optional flags create EDR test artefacts like a ransom note.
 
 ### Requirements
 * Python 3.8+  
@@ -53,6 +53,11 @@ Use at your own risk. No liability for data loss or misuse.
 ### 🧪 Ransomware-Simulation Mode
 Enable via `--ransom-sim` and optional `--sim-path` (defaults to `./testdata`). The tool XOR-encrypts files to `<name>.mocklock`, writes a ransom note and echoes a fake backup wipe. This helps EDR or XDR solutions detect malicious activity. The encryption key is always 0xAA so data can be restored. Run only in disposable test directories. To undo the simulation, run `python3 decrypt_all.py --ransom-sim --sim-path <dir>` on the same directory.
 
+### Linux Payload for EDR Testing
+`python3 -m mockbit.linux_payload --path folder` runs the ransomware simulation
+on *folder*. This makes it easy for EDR solutions to spot malicious behaviour.
+Execute only in safe test environments.
+
 ---
 
 ## Deutsch
@@ -61,7 +66,7 @@ Enable via `--ransom-sim` and optional `--sim-path` (defaults to `./testdata`). 
 * **AES‑256‑GCM** zum Verschlüsseln **und** Entschlüsseln aller Dateien eines Ordners (inkl. Unterordner).  
 * Passwortbasierte Schlüsselableitung mit **Argon2id**.  
 * Erstellung eigenständiger Binaries per **make / PyInstaller**.
-* Optionale Flags erzeugen EDR-Testdateien wie EICAR oder eine Ransom-Note.
+* Optionale Flags erzeugen EDR-Testdateien wie eine Ransom-Note.
 
 ### Voraussetzungen
 * Python 3.8+  
@@ -101,3 +106,9 @@ Mit `make clean` entfernst du die Build-Dateien.
 
 ### Haftungsausschluss
 Benutzung auf eigene Gefahr. Keine Haftung für Datenverlust oder Missbrauch.
+
+### Linux-Payload für EDR-Tests
+Mit `python3 -m mockbit.linux_payload --path ordner` wird die
+Ransomware-Simulation auf *ordner* ausgeführt. Dies ermöglicht es
+EDR-Lösungen, die Aktivität zu erkennen. Nur in sicheren Testumgebungen
+ausführen.

--- a/mockbit/linux_payload.py
+++ b/mockbit/linux_payload.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Linux payload to run the ransomware simulation for EDR testing."""
+
+import argparse
+from pathlib import Path
+
+from .ransom_sim import run_simulation
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the MockBit ransomware simulation on a target directory."
+    )
+    parser.add_argument(
+        "--path", default=".", help="Directory to use (default: current directory)"
+    )
+    args = parser.parse_args()
+    target = Path(args.path)
+    run_simulation(target)
+    print(f"Ransomware simulation executed on {target}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_linux_payload.py
+++ b/tests/test_linux_payload.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+from mockbit import linux_payload
+
+
+def test_main_runs_simulation(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_run_simulation(path: Path) -> None:
+        called["path"] = path
+
+    monkeypatch.setattr(linux_payload, "run_simulation", fake_run_simulation)
+    monkeypatch.setattr(sys, "argv", ["linux_payload", "--path", str(tmp_path)])
+    linux_payload.main()
+    assert called["path"] == tmp_path
+


### PR DESCRIPTION
## Summary
- Remove EICAR file creation; Linux payload now only runs the MockBit ransomware simulation
- Update English and German README sections to document new payload behaviour
- Replace unit test to ensure the payload invokes the simulation

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c40ec1ccc483328d4b9d92e79c6894